### PR TITLE
Add CoinGecko API integration for Bitcoin price data

### DIFF
--- a/app/callbacks.py
+++ b/app/callbacks.py
@@ -2,13 +2,90 @@
 
 from __future__ import annotations
 
-from dash import Dash
+from typing import Any, List
+
+import pandas as pd
+import plotly.graph_objects as go
+from dash import Dash, Input, Output
+from dash.exceptions import PreventUpdate
+
+from core.loaders import load_coingecko_price_history
 
 
 def register_callbacks(app: Dash) -> None:
-    """Register Dash callbacks.
+    """Register Dash callbacks for fetching data and rendering charts."""
 
-    Args:
-        app: Dash application instance.
-    """
-    _ = app
+    @app.callback(
+        Output("price-data-store", "data"),
+        Input("price-refresh", "n_intervals"),
+        prevent_initial_call=False,
+    )
+    def fetch_price_data(n_intervals: int | None) -> List[dict[str, Any]]:
+        """Retrieve Bitcoin price history from the CoinGecko API."""
+
+        if n_intervals is None:
+            raise PreventUpdate
+        frame = load_coingecko_price_history(days=365)
+        iso_frame = frame.copy()
+        iso_frame["date"] = iso_frame["date"].dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+        return list(iso_frame.to_dict("records"))
+
+    @app.callback(
+        Output("date-range-slider", "min"),
+        Output("date-range-slider", "max"),
+        Output("date-range-slider", "value"),
+        Input("price-data-store", "data"),
+    )
+    def configure_range_slider(records: list[dict[str, Any]] | None) -> tuple[int, int, list[int]]:
+        """Set the slider bounds based on the available price history."""
+
+        if not records:
+            return 0, 1, [0, 1]
+        count = len(records)
+        start_index = max(count - 90, 0)
+        return 0, count - 1, [start_index, count - 1]
+
+    @app.callback(
+        Output("price-chart", "figure"),
+        Input("price-data-store", "data"),
+        Input("date-range-slider", "value"),
+    )
+    def render_price_chart(
+        records: list[dict[str, Any]] | None, selected_range: list[int] | None
+    ) -> go.Figure:
+        """Render a line chart for the selected Bitcoin price history window."""
+
+        figure = go.Figure()
+        figure.update_layout(
+            title="Bitcoin Price (USD)",
+            margin=dict(l=40, r=20, t=60, b=40),
+            xaxis_title="Date",
+            yaxis_title="Price (USD)",
+            template="plotly_dark",
+        )
+
+        if not records:
+            return figure
+
+        frame = pd.DataFrame(records)
+        frame["date"] = pd.to_datetime(frame["date"], utc=True)
+        frame = frame.sort_values("date").reset_index(drop=True)
+
+        if not selected_range or len(selected_range) != 2:
+            start_idx, end_idx = 0, len(frame) - 1
+        else:
+            start_idx = max(selected_range[0], 0)
+            end_idx = min(selected_range[1], len(frame) - 1)
+            if start_idx > end_idx:
+                start_idx, end_idx = end_idx, start_idx
+
+        filtered = frame.iloc[start_idx : end_idx + 1]
+        figure.add_trace(
+            go.Scatter(
+                x=filtered["date"],
+                y=filtered["value"],
+                name="Price (USD)",
+                mode="lines",
+            )
+        )
+        return figure

--- a/app/layout.py
+++ b/app/layout.py
@@ -10,19 +10,24 @@ def create_layout() -> html.Div:
     return html.Div(
         className="app-shell",
         children=[
+            dcc.Store(id="price-data-store"),
+            dcc.Interval(id="price-refresh", interval=24 * 60 * 60 * 1000, n_intervals=0),
             html.Header(html.H1("Bitcoin On-Chain Analytics")),
             html.Main(
                 children=[
                     html.Section(
                         children=[
                             html.P(
-                                "Interactive dashboard for Bitcoin on-chain metrics"
+                                "Interactive dashboard loading Bitcoin metrics from the CoinGecko API"
                             ),
                             dcc.Graph(id="price-chart"),
-                            dcc.Graph(id="mvrv-chart"),
-                            dcc.Graph(id="sopr-chart"),
-                            dcc.Graph(id="active-chart"),
-                            dcc.RangeSlider(id="date-range-slider", min=0, max=1, value=[0, 1]),
+                            dcc.RangeSlider(
+                                id="date-range-slider",
+                                min=0,
+                                max=1,
+                                value=[0, 1],
+                                allowCross=False,
+                            ),
                         ]
                     ),
                 ]

--- a/core/loaders.py
+++ b/core/loaders.py
@@ -3,23 +3,35 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any, Protocol
 
 import pandas as pd
+import requests
 
 from .types import MetricFrame, MetricId
 
 
+class SupportsJSONResponse(Protocol):
+    """Protocol describing the subset of a ``requests`` response we rely on."""
+
+    status_code: int
+
+    def json(self) -> Any:  # pragma: no cover - protocol definition only
+        """Return the JSON payload from the HTTP response."""
+
+    def raise_for_status(self) -> None:  # pragma: no cover - protocol definition only
+        """Raise an HTTP error if the response indicates failure."""
+
+
+class SupportsGet(Protocol):
+    """Protocol for objects supporting the ``requests.Session.get`` API."""
+
+    def get(self, url: str, *, timeout: float) -> SupportsJSONResponse:  # pragma: no cover
+        """Perform an HTTP GET request and return a JSON-capable response."""
+
+
 def load_metric_csv(path: Path, metric: MetricId, source: str) -> MetricFrame:
-    """Load a tidy metric CSV file.
-
-    Args:
-        path: Path to the CSV file.
-        metric: Metric identifier.
-        source: Human-readable data source name.
-
-    Returns:
-        DataFrame with columns date, metric, value, and source.
-    """
+    """Load a tidy metric CSV file."""
     if not path.exists():
         raise FileNotFoundError(f"CSV not found: {path}")
     frame = pd.read_csv(path)
@@ -31,3 +43,39 @@ def load_metric_csv(path: Path, metric: MetricId, source: str) -> MetricFrame:
     frame["source"] = source
     ordered = frame[["date", "metric", "value", "source"]].sort_values("date")
     return MetricFrame(ordered.reset_index(drop=True))
+
+
+COINGECKO_MARKET_CHART_URL = (
+    "https://api.coingecko.com/api/v3/coins/bitcoin/market_chart"
+)
+
+
+def load_coingecko_price_history(
+    *,
+    days: int = 365,
+    vs_currency: str = "usd",
+    session: SupportsGet | None = None,
+) -> MetricFrame:
+    """Fetch daily Bitcoin prices from the CoinGecko market chart API."""
+
+    if days <= 0:
+        raise ValueError("`days` must be a positive integer")
+
+    http = session or requests.Session()
+    url = (
+        f"{COINGECKO_MARKET_CHART_URL}?vs_currency={vs_currency}&days={days}"
+        "&interval=daily"
+    )
+    response = http.get(url, timeout=10)
+    response.raise_for_status()
+    payload = response.json()
+    prices = payload.get("prices") if isinstance(payload, dict) else None
+    if not prices:
+        raise ValueError("CoinGecko response missing daily price data")
+    frame = pd.DataFrame(prices, columns=["timestamp_ms", "value"])
+    frame["date"] = pd.to_datetime(frame["timestamp_ms"], unit="ms", utc=True)
+    frame["metric"] = "price_usd"
+    frame["source"] = "CoinGecko API"
+    tidy = frame[["date", "metric", "value", "source"]]
+    ordered = tidy.sort_values("date").reset_index(drop=True)
+    return MetricFrame(ordered)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "dash>=2.15.0",
     "pandas>=2.2.0",
     "numpy>=1.26",
+    "requests>=2.31",
 ]
 
 [tool.black]

--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -7,7 +7,9 @@ from pathlib import Path
 import pandas as pd
 import pytest
 
-from core.loaders import load_metric_csv
+import requests
+
+from core.loaders import load_coingecko_price_history, load_metric_csv
 
 
 def test_load_metric_csv_missing_file(tmp_path: Path) -> None:
@@ -24,3 +26,52 @@ def test_load_metric_csv_happy_path(tmp_path: Path) -> None:
     result = load_metric_csv(csv_path, metric="price_usd", source="Test")
     assert list(result.columns) == ["date", "metric", "value", "source"]
     assert result.loc[0, "metric"] == "price_usd"
+
+
+class _FakeResponse:
+    def __init__(self, payload: dict[str, object], status_code: int = 200) -> None:
+        self._payload = payload
+        self.status_code = status_code
+
+    def json(self) -> dict[str, object]:
+        return self._payload
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            raise requests.HTTPError(f"{self.status_code} error")
+
+
+class _FakeSession:
+    def __init__(self, payload: dict[str, object], status_code: int = 200) -> None:
+        self._payload = payload
+        self._status_code = status_code
+        self.requested_urls: list[str] = []
+
+    def get(self, url: str, *, timeout: float) -> _FakeResponse:
+        self.requested_urls.append(url)
+        return _FakeResponse(self._payload, status_code=self._status_code)
+
+
+def test_load_coingecko_price_history_parses_payload() -> None:
+    """Convert CoinGecko price payload into a MetricFrame."""
+
+    payload = {
+        "prices": [
+            [1700000000000, 42000.0],
+            [1700086400000, 43000.5],
+        ]
+    }
+    session = _FakeSession(payload)
+    frame = load_coingecko_price_history(days=30, session=session)
+
+    assert len(frame) == 2
+    assert frame.loc[0, "metric"] == "price_usd"
+    assert any("days=30" in url for url in session.requested_urls)
+
+
+def test_load_coingecko_price_history_rejects_missing_prices() -> None:
+    """Raise ValueError when the API does not provide price data."""
+
+    session = _FakeSession({}, status_code=200)
+    with pytest.raises(ValueError):
+        load_coingecko_price_history(session=session)


### PR DESCRIPTION
## Summary
- add a CoinGecko loader that retrieves Bitcoin price history via HTTP and convert it into the shared MetricFrame format
- wire the Dash layout and callbacks to fetch the API data and render an interactive price chart backed by a date range slider
- cover the new loader behavior with unit tests and declare the requests dependency for runtime HTTP access

## Testing
- PYTHONPATH=. pytest

------
https://chatgpt.com/codex/tasks/task_e_68d7d70295c0832083fd95ab2f0d41d0