### PR TITLE
Overlay price chart with mempool hash rate data

### DIFF
--- a/app/callbacks.py
+++ b/app/callbacks.py
@@ -9,7 +9,7 @@ import plotly.graph_objects as go
 from dash import Dash, Input, Output
 from dash.exceptions import PreventUpdate
 
-from core.loaders import load_coingecko_price_history
+from core.loaders import load_coingecko_price_history, load_mempool_hash_rate
 
 
 def register_callbacks(app: Dash) -> None:
@@ -17,18 +17,27 @@ def register_callbacks(app: Dash) -> None:
 
     @app.callback(
         Output("price-data-store", "data"),
+        Output("hashrate-data-store", "data"),
         Input("price-refresh", "n_intervals"),
         prevent_initial_call=False,
     )
-    def fetch_price_data(n_intervals: int | None) -> List[dict[str, Any]]:
-        """Retrieve Bitcoin price history from the CoinGecko API."""
+    def fetch_market_data(
+        n_intervals: int | None,
+    ) -> tuple[List[dict[str, Any]], List[dict[str, Any]]]:
+        """Retrieve Bitcoin market data from external APIs."""
 
         if n_intervals is None:
             raise PreventUpdate
         frame = load_coingecko_price_history(days=365)
         iso_frame = frame.copy()
         iso_frame["date"] = iso_frame["date"].dt.strftime("%Y-%m-%dT%H:%M:%SZ")
-        return list(iso_frame.to_dict("records"))
+        price_records = list(iso_frame.to_dict("records"))
+
+        hashrate_frame = load_mempool_hash_rate(period="1y")
+        iso_hashrate = hashrate_frame.copy()
+        iso_hashrate["date"] = iso_hashrate["date"].dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+        hashrate_records = list(iso_hashrate.to_dict("records"))
+        return price_records, hashrate_records
 
     @app.callback(
         Output("date-range-slider", "min"),
@@ -36,7 +45,9 @@ def register_callbacks(app: Dash) -> None:
         Output("date-range-slider", "value"),
         Input("price-data-store", "data"),
     )
-    def configure_range_slider(records: list[dict[str, Any]] | None) -> tuple[int, int, list[int]]:
+    def configure_range_slider(
+        records: list[dict[str, Any]] | None,
+    ) -> tuple[int, int, list[int]]:
         """Set the slider bounds based on the available price history."""
 
         if not records:
@@ -48,26 +59,35 @@ def register_callbacks(app: Dash) -> None:
     @app.callback(
         Output("price-chart", "figure"),
         Input("price-data-store", "data"),
+        Input("hashrate-data-store", "data"),
         Input("date-range-slider", "value"),
     )
     def render_price_chart(
-        records: list[dict[str, Any]] | None, selected_range: list[int] | None
+        price_records: list[dict[str, Any]] | None,
+        hashrate_records: list[dict[str, Any]] | None,
+        selected_range: list[int] | None,
     ) -> go.Figure:
         """Render a line chart for the selected Bitcoin price history window."""
 
         figure = go.Figure()
         figure.update_layout(
-            title="Bitcoin Price (USD)",
+            title="Bitcoin Price and Hash Rate",
             margin=dict(l=40, r=20, t=60, b=40),
             xaxis_title="Date",
-            yaxis_title="Price (USD)",
+            yaxis=dict(title="Price (USD)"),
+            yaxis2=dict(
+                title="Hash Rate (EH/s)", overlaying="y", side="right", showgrid=False
+            ),
             template="plotly_dark",
+            legend=dict(
+                orientation="h", yanchor="bottom", y=1.02, xanchor="right", x=1
+            ),
         )
 
-        if not records:
+        if not price_records:
             return figure
 
-        frame = pd.DataFrame(records)
+        frame = pd.DataFrame(price_records)
         frame["date"] = pd.to_datetime(frame["date"], utc=True)
         frame = frame.sort_values("date").reset_index(drop=True)
 
@@ -80,6 +100,9 @@ def register_callbacks(app: Dash) -> None:
                 start_idx, end_idx = end_idx, start_idx
 
         filtered = frame.iloc[start_idx : end_idx + 1]
+        filtered = filtered.reset_index(drop=True)
+        start_date = filtered["date"].iloc[0]
+        end_date = filtered["date"].iloc[-1]
         figure.add_trace(
             go.Scatter(
                 x=filtered["date"],
@@ -88,4 +111,24 @@ def register_callbacks(app: Dash) -> None:
                 mode="lines",
             )
         )
+
+        if hashrate_records:
+            hashrate_frame = pd.DataFrame(hashrate_records)
+            hashrate_frame["date"] = pd.to_datetime(hashrate_frame["date"], utc=True)
+            hashrate_frame = hashrate_frame.sort_values("date").reset_index(drop=True)
+            mask = (hashrate_frame["date"] >= start_date) & (
+                hashrate_frame["date"] <= end_date
+            )
+            subset = hashrate_frame.loc[mask]
+            if not subset.empty:
+                figure.add_trace(
+                    go.Scatter(
+                        x=subset["date"],
+                        y=subset["value"],
+                        name="Hash Rate (EH/s)",
+                        mode="lines",
+                        line=dict(color="#FFA500"),
+                        yaxis="y2",
+                    )
+                )
         return figure

--- a/app/layout.py
+++ b/app/layout.py
@@ -11,14 +11,17 @@ def create_layout() -> html.Div:
         className="app-shell",
         children=[
             dcc.Store(id="price-data-store"),
-            dcc.Interval(id="price-refresh", interval=24 * 60 * 60 * 1000, n_intervals=0),
+            dcc.Store(id="hashrate-data-store"),
+            dcc.Interval(
+                id="price-refresh", interval=24 * 60 * 60 * 1000, n_intervals=0
+            ),
             html.Header(html.H1("Bitcoin On-Chain Analytics")),
             html.Main(
                 children=[
                     html.Section(
                         children=[
                             html.P(
-                                "Interactive dashboard loading Bitcoin metrics from the CoinGecko API"
+                                "Interactive dashboard loading Bitcoin metrics from the CoinGecko and mempool.space APIs"
                             ),
                             dcc.Graph(id="price-chart"),
                             dcc.RangeSlider(

--- a/core/loaders.py
+++ b/core/loaders.py
@@ -26,7 +26,9 @@ class SupportsJSONResponse(Protocol):
 class SupportsGet(Protocol):
     """Protocol for objects supporting the ``requests.Session.get`` API."""
 
-    def get(self, url: str, *, timeout: float) -> SupportsJSONResponse:  # pragma: no cover
+    def get(
+        self, url: str, *, timeout: float
+    ) -> SupportsJSONResponse:  # pragma: no cover
         """Perform an HTTP GET request and return a JSON-capable response."""
 
 
@@ -48,6 +50,8 @@ def load_metric_csv(path: Path, metric: MetricId, source: str) -> MetricFrame:
 COINGECKO_MARKET_CHART_URL = (
     "https://api.coingecko.com/api/v3/coins/bitcoin/market_chart"
 )
+
+MEMPOOL_HASHRATE_URL = "https://mempool.space/api/v1/hashrate"
 
 
 def load_coingecko_price_history(
@@ -77,5 +81,69 @@ def load_coingecko_price_history(
     frame["metric"] = "price_usd"
     frame["source"] = "CoinGecko API"
     tidy = frame[["date", "metric", "value", "source"]]
+    ordered = tidy.sort_values("date").reset_index(drop=True)
+    return MetricFrame(ordered)
+
+
+def load_mempool_hash_rate(
+    *, period: str = "1y", session: SupportsGet | None = None
+) -> MetricFrame:
+    """Fetch Bitcoin hash rate history from the mempool.space API."""
+
+    if not period:
+        raise ValueError("`period` must be a non-empty string")
+
+    http = session or requests.Session()
+    url = f"{MEMPOOL_HASHRATE_URL}/{period}"
+    response = http.get(url, timeout=10)
+    response.raise_for_status()
+
+    payload = response.json()
+    if not isinstance(payload, list) or not payload:
+        raise ValueError("mempool.space response missing hash rate data")
+
+    frame = pd.DataFrame(payload)
+    if frame.empty:
+        raise ValueError("mempool.space response empty")
+
+    value_column = next(
+        (
+            column
+            for column in ("avgHashrate", "hashrate", "value")
+            if column in frame.columns
+        ),
+        None,
+    )
+    if value_column is None:
+        raise ValueError("mempool.space payload missing hash rate values")
+
+    time_column = next(
+        (column for column in ("time", "timestamp", "date") if column in frame.columns),
+        None,
+    )
+    if time_column is None:
+        raise ValueError("mempool.space payload missing timestamps")
+
+    raw_times = frame[time_column]
+    if pd.api.types.is_numeric_dtype(raw_times):
+        max_time = float(raw_times.max()) if not raw_times.empty else 0.0
+        unit = "ms" if max_time > 10**12 else "s"
+        dates = pd.to_datetime(raw_times, unit=unit, utc=True)
+    else:
+        dates = pd.to_datetime(raw_times, utc=True, errors="raise")
+
+    values = pd.to_numeric(frame[value_column], errors="coerce")
+    if values.isna().any():
+        raise ValueError("mempool.space payload contained invalid hash rate values")
+
+    tidy = pd.DataFrame(
+        {
+            "date": dates,
+            "metric": "hash_rate_eh_s",
+            "value": values.astype("float64"),
+            "source": "mempool.space API",
+        }
+    )
+
     ordered = tidy.sort_values("date").reset_index(drop=True)
     return MetricFrame(ordered)

--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -9,7 +9,11 @@ import pytest
 
 import requests
 
-from core.loaders import load_coingecko_price_history, load_metric_csv
+from core.loaders import (
+    load_coingecko_price_history,
+    load_mempool_hash_rate,
+    load_metric_csv,
+)
 
 
 def test_load_metric_csv_missing_file(tmp_path: Path) -> None:
@@ -29,11 +33,11 @@ def test_load_metric_csv_happy_path(tmp_path: Path) -> None:
 
 
 class _FakeResponse:
-    def __init__(self, payload: dict[str, object], status_code: int = 200) -> None:
+    def __init__(self, payload: object, status_code: int = 200) -> None:
         self._payload = payload
         self.status_code = status_code
 
-    def json(self) -> dict[str, object]:
+    def json(self) -> object:
         return self._payload
 
     def raise_for_status(self) -> None:
@@ -42,7 +46,7 @@ class _FakeResponse:
 
 
 class _FakeSession:
-    def __init__(self, payload: dict[str, object], status_code: int = 200) -> None:
+    def __init__(self, payload: object, status_code: int = 200) -> None:
         self._payload = payload
         self._status_code = status_code
         self.requested_urls: list[str] = []
@@ -75,3 +79,26 @@ def test_load_coingecko_price_history_rejects_missing_prices() -> None:
     session = _FakeSession({}, status_code=200)
     with pytest.raises(ValueError):
         load_coingecko_price_history(session=session)
+
+
+def test_load_mempool_hash_rate_parses_payload() -> None:
+    """Convert mempool.space hash rate payload into a MetricFrame."""
+
+    payload = [
+        {"time": 1700000000, "avgHashrate": 410.5},
+        {"time": 1700086400, "avgHashrate": 415.2},
+    ]
+    session = _FakeSession(payload)
+    frame = load_mempool_hash_rate(period="1y", session=session)
+
+    assert len(frame) == 2
+    assert frame.loc[0, "metric"] == "hash_rate_eh_s"
+    assert any("hashrate/1y" in url for url in session.requested_urls)
+
+
+def test_load_mempool_hash_rate_rejects_missing_series() -> None:
+    """Raise ValueError when mempool.space omits hash rate observations."""
+
+    session = _FakeSession([], status_code=200)
+    with pytest.raises(ValueError):
+        load_mempool_hash_rate(session=session)


### PR DESCRIPTION
## Summary
- add a mempool.space loader that normalizes hash rate data into the shared metric frame
- extend the dashboard callbacks and layout to fetch hash rate records alongside price and render a dual-axis overlay
- cover the new loader behaviour with tests for happy-path and error handling

## Testing
- PYTHONPATH=. pytest

------
https://chatgpt.com/codex/tasks/task_e_68d7ead32118832084957e6e0f34c8ac